### PR TITLE
Fix: Prevent negative quantities in inventory models

### DIFF
--- a/inventario/models.py
+++ b/inventario/models.py
@@ -1,6 +1,7 @@
 # inventario/models.py
 from django.db import models
-from django.conf import settings # Necesario para el historial
+from django.conf import settings
+from django.core.validators import MinValueValidator
 # Se elimina la importación de CloudinaryField
 
 # --- NUEVOS MODELOS PARA 'INVENTARIO' ---
@@ -33,14 +34,14 @@ class Medicamento(models.Model):
 
 class Alimento(models.Model):
     nombre = models.CharField(max_length=100, help_text="Ej: Heno, Silo de maíz, Sal mineral")
-    cantidad_kg = models.DecimalField(max_digits=10, decimal_places=2)
+    cantidad_kg = models.DecimalField(max_digits=10, decimal_places=2, validators=[MinValueValidator(0.0)])
     ubicacion = models.ForeignKey('caracteristicas.Ubicacion', on_delete=models.SET_NULL, null=True)
     def __str__(self): return self.nombre
 
 class ControlPlaga(models.Model):
     nombre_producto = models.CharField(max_length=100)
     tipo = models.CharField(max_length=50, help_text="Ej: Herbicida, Insecticida")
-    cantidad_litros = models.DecimalField(max_digits=10, decimal_places=2)
+    cantidad_litros = models.DecimalField(max_digits=10, decimal_places=2, validators=[MinValueValidator(0.0)])
     def __str__(self): return self.nombre_producto
 
 class Potrero(models.Model):
@@ -57,5 +58,5 @@ class Mantenimiento(models.Model):
 
 class Combustible(models.Model):
     tipo = models.CharField(max_length=50, help_text="Ej: Diesel, Gasolina")
-    cantidad_galones = models.DecimalField(max_digits=10, decimal_places=2)
+    cantidad_galones = models.DecimalField(max_digits=10, decimal_places=2, validators=[MinValueValidator(0.0)])
     def __str__(self): return f"{self.cantidad_galones} galones de {self.tipo}"

--- a/inventario/tests.py
+++ b/inventario/tests.py
@@ -1,3 +1,51 @@
 from django.test import TestCase
+from django.core.exceptions import ValidationError
+from .models import Alimento, ControlPlaga, Combustible
+from caracteristicas.models import Ubicacion
 
-# Create your tests here.
+class AlimentoModelTest(TestCase):
+
+    def setUp(self):
+        self.ubicacion = Ubicacion.objects.create(nombre="Bodega")
+
+    def test_cantidad_kg_cannot_be_negative(self):
+        """
+        Test that an Alimento with a negative cantidad_kg raises a ValidationError.
+        """
+        alimento = Alimento(
+            nombre="Heno",
+            cantidad_kg=-10.5,
+            ubicacion=self.ubicacion
+        )
+
+        with self.assertRaises(ValidationError):
+            alimento.full_clean()
+
+class ControlPlagaModelTest(TestCase):
+
+    def test_cantidad_litros_cannot_be_negative(self):
+        """
+        Test that a ControlPlaga with a negative cantidad_litros raises a ValidationError.
+        """
+        control_plaga = ControlPlaga(
+            nombre_producto="Herbicida",
+            tipo="Herbicida",
+            cantidad_litros=-5.0
+        )
+
+        with self.assertRaises(ValidationError):
+            control_plaga.full_clean()
+
+class CombustibleModelTest(TestCase):
+
+    def test_cantidad_galones_cannot_be_negative(self):
+        """
+        Test that a Combustible with a negative cantidad_galones raises a ValidationError.
+        """
+        combustible = Combustible(
+            tipo="Diesel",
+            cantidad_galones=-20.0
+        )
+
+        with self.assertRaises(ValidationError):
+            combustible.full_clean()


### PR DESCRIPTION
The `Alimento`, `ControlPlaga`, and `Combustible` models allowed negative values for their quantity fields (`cantidad_kg`, `cantidad_litros`, `cantidad_galones`). This is a logical error as inventory quantities cannot be negative.

This commit adds a `MinValueValidator(0.0)` to these fields to enforce a non-negative constraint at the model validation level.

New unit tests have been added to verify that a `ValidationError` is raised when attempting to create model instances with negative quantities.